### PR TITLE
Add `MongoId` assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following set of extra asserts are provided by this package:
 * Ip
 * Iso3166Country
 * Json
+* MongoId
 * NotEmpty
 * NullOrString
 * PlainObject
@@ -130,6 +131,10 @@ Tests if the value is a valid ISO-3166 country by alpha-3 code, alpha-2 code or 
 ### Json
 
 Tests if the value is valid json.
+
+### MongoId
+
+Tests if the value is a valid MongoDB id object or string representation.
 
 ### NotEmpty
 

--- a/lib/asserts/mongo-id-assert.js
+++ b/lib/asserts/mongo-id-assert.js
@@ -1,0 +1,34 @@
+
+/**
+ * Module dependencies.
+ */
+
+var objectid = require('objectid');
+var Violation = require('validator.js').Violation;
+
+/**
+ * Export `MongoIdAssert`.
+ */
+
+module.exports = function() {
+
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'MongoId';
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = function(value) {
+    if (!objectid.isValid(value)) {
+      throw new Violation(this, value);
+    }
+
+    return true;
+  };
+
+  return this;
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "iso-3166-1-data": "0.0.2",
     "lodash": "^2.4.1",
     "moment": "^2.8.4",
+    "objectid": "3.1.0",
     "provinces": "^0.2.0",
     "require-dir": "^0.1.0",
     "to-pascal-case": "0.0.2",

--- a/test/asserts/mongo-id-assert_test.js
+++ b/test/asserts/mongo-id-assert_test.js
@@ -1,0 +1,50 @@
+
+/**
+ * Module dependencies.
+ */
+
+var Assert = require('validator.js').Assert;
+var Violation = require('validator.js').Violation;
+var assert = require('../../lib/asserts/mongo-id-assert');
+var objectid = require('objectid');
+var should = require('should');
+
+/**
+ * Test `MongoIdAssert`.
+ */
+
+describe('MongoIdAssert', function() {
+  before(function() {
+    Assert.prototype.MongoId = assert;
+  });
+
+  it('should throw an error if the input value is not a valid MongoDB id', function() {
+    /*jshint -W009 */
+    var choices = [[], 123, new Array(), 'foobar', {}, { id: 'bar' }];
+    /*jshint +W009 */
+
+    choices.forEach(function(choice) {
+      try {
+        new Assert().MongoId().validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+      }
+    });
+  });
+
+  it('should expose `assert` equal to `MongoId`', function() {
+    try {
+      new Assert().MongoId().validate('FOO');
+
+      should.fail();
+    } catch(e) {
+      e.show().assert.should.equal('MongoId');
+    }
+  });
+
+  it('should accept a valid MongoDB id object', function() {
+    new Assert().MongoId().validate(objectid());
+  });
+});


### PR DESCRIPTION
This PR adds `MongoID` Assert that checks if the value is a valid MongoDB id object or string representation.