### PR TITLE
Add URI assert

### DIFF
--- a/lib/asserts/uri-assert.js
+++ b/lib/asserts/uri-assert.js
@@ -1,0 +1,77 @@
+
+/**
+* Module dependencies.
+*/
+
+var _ = require('lodash');
+var URI = require('URIjs');
+var Validator = require('validator.js').Validator;
+var Violation = require('validator.js').Violation;
+var fmt = require('util').format;
+
+/**
+* Export `UriAssert`.
+*/
+
+module.exports = function(constraints) {
+
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'Uri';
+
+  /**
+   * Constraints.
+   */
+
+  this.constraints = constraints || {};
+
+  /**
+   * Validate constraints.
+   */
+
+  _.forEach(this.constraints, function(constraint, key) {
+    if (!_.has(URI.prototype, key)) {
+      throw new Error(fmt('Invalid constraint "%s=%s"', key, constraint));
+    }
+  });
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = function(value) {
+    if ('string' !== typeof value) {
+      /* jshint camelcase: false */
+      throw new Violation(this, value, { value: Validator.errorCode.must_be_a_string });
+      /* jshint camelcase: true */
+    }
+
+    var uri;
+
+    try {
+      uri = new URI(value)
+    } catch (e) {
+      throw new Violation(this, value, { constraints: this.constraints });
+    }
+
+    // URIs must have at least a hostname and protocol.
+    if (!uri.hostname() || !uri.protocol()) {
+      throw new Violation(this, value, { constraints: this.constraints });
+    }
+
+    // Validate that each constraint matches exactly.
+    _.forEach(this.constraints, function(constraint, key) {
+      if (constraint === uri[key]()) {
+        return;
+      }
+
+      throw new Violation(this, value, { constraints: this.constraints });
+    }, this);
+
+    return true;
+  };
+
+  return this;
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "URIjs": "^1.15.1",
     "bignumber.js": "^2.0.7",
     "isoc": "0.0.1",
     "lodash": "^3.9.1",

--- a/test/asserts/uri-assert_test.js
+++ b/test/asserts/uri-assert_test.js
@@ -1,0 +1,112 @@
+
+/**
+ * Module dependencies.
+ */
+
+var Assert = require('validator.js').Assert;
+var Validator = require('validator.js').Validator;
+var Violation = require('validator.js').Violation;
+var assert = require('../../lib/asserts/uri-assert');
+var fmt = require('util').format;
+var should = require('should');
+
+/**
+ * Test `UriAssert`.
+ */
+
+describe('UriAssert', function() {
+  before(function() {
+    Assert.prototype.Uri = assert;
+  });
+
+  it('should throw an error if the constraint is invalid', function() {
+    try {
+      new Assert().Uri({ foo: 'bar' });
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Error);
+      e.message.should.equal('Invalid constraint "foo=bar"');
+    }
+  });
+
+  it('should throw an error if the input value is not a string', function() {
+    var choices = [[], {}, 123];
+
+    choices.forEach(function(choice) {
+      try {
+        new Assert().Uri().validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        /* jshint camelcase: false */
+        e.violation.value.should.equal(Validator.errorCode.must_be_a_string);
+        /* jshint camelcase: true */
+      }
+    });
+  });
+
+  it('should throw an error if the uri does not contain a `hostname`', function() {
+    try {
+      new Assert().Uri().validate(fmt('foo-%s-bar', new Array(248).join('-')));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+    }
+  });
+
+  it('should throw an error if the uri does not contain a `protocol`', function() {
+    try {
+      new Assert().Uri().validate('foobar.com');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+    }
+  });
+
+  it('should throw an error if the uri does not match the constraints', function() {
+    try {
+      new Assert().Uri({ protocol: 'http' }).validate(fmt('https://%s@bar.com', new Array(248).join('-')));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+    }
+  });
+
+  it('should expose `constraints` on the violation', function() {
+    try {
+      new Assert().Uri({ protocol: 'http' }).validate('https://foobar.com');
+
+      should.fail();
+    } catch(e) {
+      e.show().violation.constraints.should.eql({ protocol: 'http' });
+    }
+  });
+
+  it('should expose `assert` equal to `Uri`', function() {
+    try {
+      new Assert().Uri().validate('foo');
+
+      should.fail();
+    } catch(e) {
+      e.show().assert.should.equal('Uri');
+    }
+  });
+
+  it('should accept valid uris', function() {
+    [
+      'http://foobar.com',
+      'http://føøbåz.com',
+      'http://foobar.com',
+      'https://foobar.com',
+      'ftp://foobar.com',
+      'biz://foobar.com'
+    ].forEach(function(choice) {
+      new Assert().Uri().validate(choice);
+    });
+  });
+});


### PR DESCRIPTION
Adds a URI assert by relying on the [URIjs](https://github.com/medialize/URI.js) library.

Also allows forcing the URI's protocol to match a configured value.