### PR TITLE
Add null or date assert

### DIFF
--- a/lib/asserts/date-diff-greater-than-assert.js
+++ b/lib/asserts/date-diff-greater-than-assert.js
@@ -4,9 +4,18 @@
  */
 
 var _ = require('lodash');
-var DateAssert = require('./date-assert');
+var Asserts = require('validator');
+var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var moment = require('moment');
+
+/**
+ * Add custom error code for `date` or `string`.
+ */
+
+/* jshint camelcase: false */
+Validator.errorCode.must_be_a_date_or_a_string = 'must_be_a_date_or_a_string';
+/* jshint camelcase: true */
 
 /**
  * Export `DateDiffGreaterThanAssert`.
@@ -50,9 +59,13 @@ module.exports = function(threshold, options) {
    */
 
   this.validate = function(value) {
-    try {
-      new DateAssert().validate(value);
-    } catch (e) {
+    if ('string' !== typeof value && !(value instanceof Date)) {
+      /* jshint camelcase: false */
+      throw new Violation(this, value, { value: Validator.errorCode.must_be_a_date_or_a_string });
+      /* jshint camelcase: true */
+    }
+
+    if (true !== Asserts.isDate(value)) {
       throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
     }
 

--- a/lib/asserts/date-diff-less-than-assert.js
+++ b/lib/asserts/date-diff-less-than-assert.js
@@ -4,9 +4,18 @@
  */
 
 var _ = require('lodash');
-var DateAssert = require('./date-assert');
+var Asserts = require('validator');
+var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var moment = require('moment');
+
+/**
+ * Add custom error code for `date` or `string`.
+ */
+
+/* jshint camelcase: false */
+Validator.errorCode.must_be_a_date_or_a_string = 'must_be_a_date_or_a_string';
+/* jshint camelcase: true */
 
 /**
  * Export `DateDiffLessThanAssert`.
@@ -50,9 +59,13 @@ module.exports = function(threshold, options) {
    */
 
   this.validate = function(value) {
-    try {
-      new DateAssert().validate(value);
-    } catch (e) {
+    if ('string' !== typeof value && !(value instanceof Date)) {
+      /* jshint camelcase: false */
+      throw new Violation(this, value, { value: Validator.errorCode.must_be_a_date_or_a_string });
+      /* jshint camelcase: true */
+    }
+
+    if (true !== Asserts.isDate(value)) {
       throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
     }
 

--- a/lib/asserts/null-or-date-assert.js
+++ b/lib/asserts/null-or-date-assert.js
@@ -1,0 +1,53 @@
+
+/**
+ * Module dependencies.
+ */
+
+var Asserts = require('validator');
+var Validator = require('validator.js').Validator;
+var Violation = require('validator.js').Violation;
+
+/**
+ * Add custom error code for `date` or `null`.
+ */
+
+/* jshint camelcase: false */
+Validator.errorCode.must_be_null_or_a_date = 'must_be_null_or_a_date';
+/* jshint camelcase: true */
+
+/**
+ * Export `NullOrDateAssert`.
+ */
+
+module.exports = function() {
+
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'NullOrDate';
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = function(value) {
+    if (null === value) {
+      return true;
+    }
+
+    if ('string' !== typeof value && !(value instanceof Date)) {
+      /* jshint camelcase: false */
+      throw new Violation(this, value, { value: Validator.errorCode.must_be_null_or_a_date });
+      /* jshint camelcase: true */
+    }
+
+    if (true !== Asserts.isDate(value)) {
+      throw new Violation(this, value);
+    }
+
+    return true;
+  };
+
+  return this;
+};

--- a/lib/asserts/null-or-string-assert.js
+++ b/lib/asserts/null-or-string-assert.js
@@ -12,7 +12,7 @@ var Violation = require('validator.js').Violation;
  */
 
 /* jshint camelcase: false */
-Validator.errorCode.must_be_a_null_or_a_string = 'must_be_a_null_or_a_string';
+Validator.errorCode.must_be_null_or_a_string = 'must_be_null_or_a_string';
 /* jshint camelcase: true */
 
 /**
@@ -43,7 +43,7 @@ module.exports = function(boundaries) {
   this.validate = function(value) {
     if (null !== value && 'string' !== typeof value) {
       /* jshint camelcase: false */
-      throw new Violation(this, value, { value: Validator.errorCode.must_be_a_null_or_a_string });
+      throw new Violation(this, value, { value: Validator.errorCode.must_be_null_or_a_string });
       /* jshint camelcase: true */
     }
 

--- a/test/asserts/date-diff-greater-than-assert_test.js
+++ b/test/asserts/date-diff-greater-than-assert_test.js
@@ -4,6 +4,7 @@
  */
 
 var Assert = require('validator.js').Assert;
+var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var assert = require('../../lib/asserts/date-diff-greater-than-assert');
 var sinon = require('sinon');
@@ -53,7 +54,7 @@ describe('DateDiffGreaterThanAssert', function() {
   });
 
   it('should throw an error if the input value is not a date', function() {
-    var choices = [[], {}, ''];
+    var choices = [[], {}];
 
     choices.forEach(function(choice) {
       try {
@@ -62,6 +63,9 @@ describe('DateDiffGreaterThanAssert', function() {
         should.fail();
       } catch (e) {
         e.should.be.instanceOf(Violation);
+        /* jshint camelcase: false */
+        e.violation.value.should.equal(Validator.errorCode.must_be_a_date_or_a_string);
+        /* jshint camelcase: true */
       }
     });
   });

--- a/test/asserts/date-diff-less-than-assert_test.js
+++ b/test/asserts/date-diff-less-than-assert_test.js
@@ -4,6 +4,7 @@
  */
 
 var Assert = require('validator.js').Assert;
+var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var assert = require('../../lib/asserts/date-diff-less-than-assert');
 var sinon = require('sinon');
@@ -53,7 +54,7 @@ describe('DateDiffLessThanAssert', function() {
   });
 
   it('should throw an error if the input value is not a date', function() {
-    var choices = [[], {}, ''];
+    var choices = [[], {}];
 
     choices.forEach(function(choice) {
       try {
@@ -62,6 +63,9 @@ describe('DateDiffLessThanAssert', function() {
         should.fail();
       } catch (e) {
         e.should.be.instanceOf(Violation);
+        /* jshint camelcase: false */
+        e.violation.value.should.equal(Validator.errorCode.must_be_a_date_or_a_string);
+        /* jshint camelcase: true */
       }
     });
   });

--- a/test/asserts/null-or-date-assert_test.js
+++ b/test/asserts/null-or-date-assert_test.js
@@ -1,0 +1,59 @@
+
+/**
+ * Module dependencies.
+ */
+
+var Assert = require('validator.js').Assert;
+var Validator = require('validator.js').Validator;
+var Violation = require('validator.js').Violation;
+var assert = require('../../lib/asserts/null-or-date-assert');
+var should = require('should');
+
+/**
+ * Test `NullOrDateAssert`.
+ */
+
+describe('NullOrDateAssert', function() {
+  before(function() {
+    Assert.prototype.NullOrDate = assert;
+  });
+
+  it('should throw an error if the input value is not a `null` or a date', function() {
+    var choices = [[], {}, 123];
+
+    choices.forEach(function(choice) {
+      try {
+        new Assert().NullOrDate().validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        /* jshint camelcase: false */
+        e.violation.value.should.equal(Validator.errorCode.must_be_null_or_a_date);
+        /* jshint camelcase: true */
+      }
+    });
+  });
+
+  it('should expose `assert` equal to `NullOrDate`', function() {
+    try {
+      new Assert().NullOrDate().validate({});
+
+      should.fail();
+    } catch(e) {
+      e.show().assert.should.equal('NullOrDate');
+    }
+  });
+
+  it('should accept `null`', function() {
+    new Assert().NullOrDate().validate(null);
+  });
+
+  it('should accept a date', function() {
+    new Assert().NullOrDate().validate(new Date());
+  });
+
+  it('should accept a string', function() {
+    new Assert().NullOrDate().validate('2014-10-16');
+  });
+});

--- a/test/asserts/null-or-string-assert_test.js
+++ b/test/asserts/null-or-string-assert_test.js
@@ -29,7 +29,7 @@ describe('NullOrStringAssert', function() {
       } catch (e) {
         e.should.be.instanceOf(Violation);
         /* jshint camelcase: false */
-        e.violation.value.should.equal(Validator.errorCode.must_be_a_null_or_a_string);
+        e.violation.value.should.equal(Validator.errorCode.must_be_null_or_a_string);
         /* jshint camelcase: true */
       }
     });


### PR DESCRIPTION
* Adds a `NullOrDate` assert.
* Fixes an issue with the `DateDiffGreaterThan` and `DateDiffLessThan` asserts that were incorrectly calling a dependent assert which was never properly initialized.

R=@ruimarinho 