### PR TITLE
Move dependencies to peer dependencies

### DIFF
--- a/lib/asserts/country-assert.js
+++ b/lib/asserts/country-assert.js
@@ -3,13 +3,13 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var countries = require('world-countries').concat(
   require('world-countries/data/bes.divisions'),
   require('world-countries/data/shn.divisions')
 );
+var find = require('lodash/collection/find');
 
 /**
  * Export `CountryAssert`.
@@ -35,21 +35,21 @@ module.exports = function() {
     }
 
     // Test by `alpha-3` code.
-    var country = _.find(countries, { cca3: value });
+    var country = find(countries, { cca3: value });
 
     // Test by `alpha-2` code.
     if (!country) {
-      country = _.find(countries, { cca2: value });
+      country = find(countries, { cca2: value });
     }
 
     var name = value.toLocaleUpperCase();
 
     // Test by `name`.
     if (!country) {
-      country = _.find(countries, function(country) {
+      country = find(countries, function(country) {
         return country.name.common.toLocaleUpperCase() === name
           || country.name.official.toLocaleUpperCase() === name
-          || _.find(country.altSpellings, function(altSpelling) {
+          || find(country.altSpellings, function(altSpelling) {
               return altSpelling.toLocaleUpperCase() === name;
           });
       });

--- a/lib/asserts/date-diff-greater-than-assert.js
+++ b/lib/asserts/date-diff-greater-than-assert.js
@@ -3,10 +3,10 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Asserts = require('validator');
 var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
+var assign = require('lodash/object/assign');
 var moment = require('moment');
 
 /**
@@ -47,7 +47,7 @@ module.exports = function(threshold, options) {
    * Options.
    */
 
-  this.options = _.extend(this, {
+  this.options = assign(this, {
     absolute: false,
     asFloat: false,
     fromDate: null,

--- a/lib/asserts/date-diff-less-than-assert.js
+++ b/lib/asserts/date-diff-less-than-assert.js
@@ -3,10 +3,10 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Asserts = require('validator');
 var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
+var assign = require('lodash/object/assign');
 var moment = require('moment');
 
 /**
@@ -47,7 +47,7 @@ module.exports = function(threshold, options) {
    * Options.
    */
 
-  this.options = _.extend(this, {
+  this.options = assign(this, {
     absolute: false,
     asFloat: false,
     fromDate: null,

--- a/lib/asserts/equal-keys-assert.js
+++ b/lib/asserts/equal-keys-assert.js
@@ -3,9 +3,10 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
+var difference = require('lodash/array/difference');
+var isPlainObject = require('lodash/lang/isPlainObject');
 
 /**
  * Add custom error code for a plain object.
@@ -38,16 +39,16 @@ module.exports = function(keys) {
    */
 
   this.validate = function(value) {
-    if (!_.isPlainObject(value)) {
+    if (!isPlainObject(value)) {
       /* jshint camelcase: false */
       throw new Violation(this, value, { value: Validator.errorCode.must_be_a_plain_object });
       /* jshint camelcase: true */
     }
 
-    var difference = _.difference(_.keys(value), this.keys);
+    var diff = difference(Object.keys(value), this.keys);
 
-    if (difference.length > 0) {
-      throw new Violation(this, value, { difference: difference });
+    if (diff.length > 0) {
+      throw new Violation(this, value, { difference: diff });
     }
 
     return true;

--- a/lib/asserts/iso-3166-country-assert.js
+++ b/lib/asserts/iso-3166-country-assert.js
@@ -3,10 +3,10 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var countries = require('isoc');
+var find = require('lodash/collection/find');
 
 /**
  * Export `Iso3166CountryAssert`.
@@ -38,18 +38,18 @@ module.exports = function() {
     }
 
     // Test by `alpha-3` code.
-    var country = _.find(this.countries, { alpha3: value });
+    var country = find(this.countries, { alpha3: value });
 
     // Test by `alpha-2` code.
     if (!country) {
-      country = _.find(this.countries, { alpha2: value });
+      country = find(this.countries, { alpha2: value });
     }
 
     // Test by `name`.
     var name = value.toLocaleUpperCase();
 
     if (!country) {
-      country = _.find(countries, function(country) {
+      country = find(countries, function(country) {
         return country.name.short.toLocaleUpperCase() === name
           || country.name.uppercase.toLocaleUpperCase() === name
       });

--- a/lib/asserts/not-empty-assert.js
+++ b/lib/asserts/not-empty-assert.js
@@ -3,8 +3,8 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Violation = require('validator.js').Violation;
+var isEmpty = require('lodash/lang/isEmpty');
 
 /**
  * Export `NotEmptyAssert`.
@@ -23,7 +23,7 @@ module.exports = function() {
    */
 
   this.validate = function(value) {
-    if (_.isEmpty(value)) {
+    if (isEmpty(value)) {
       throw new Violation(this, value);
     }
 

--- a/lib/asserts/plain-object-assert.js
+++ b/lib/asserts/plain-object-assert.js
@@ -3,8 +3,8 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Violation = require('validator.js').Violation;
+var isPlainObject = require('lodash/lang/isPlainObject');
 
 /**
  * Export `PlainObjectAssert`.
@@ -23,7 +23,7 @@ module.exports = function() {
    */
 
   this.validate = function(value) {
-    if (!_.isPlainObject(value)) {
+    if (!isPlainObject(value)) {
       throw new Violation(this, value);
     }
 

--- a/lib/asserts/uri-assert.js
+++ b/lib/asserts/uri-assert.js
@@ -3,11 +3,12 @@
 * Module dependencies.
 */
 
-var _ = require('lodash');
 var URI = require('URIjs');
 var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var fmt = require('util').format;
+var forEach = require('lodash/collection/forEach');
+var has = require('lodash/object/has');
 
 /**
 * Export `UriAssert`.
@@ -31,8 +32,8 @@ module.exports = function(constraints) {
    * Validate constraints.
    */
 
-  _.forEach(this.constraints, function(constraint, key) {
-    if (!_.has(URI.prototype, key)) {
+  forEach(this.constraints, function(constraint, key) {
+    if (!has(URI.prototype, key)) {
       throw new Error(fmt('Invalid constraint "%s=%s"', key, constraint));
     }
   });
@@ -62,7 +63,7 @@ module.exports = function(constraints) {
     }
 
     // Validate that each constraint matches exactly.
-    _.forEach(this.constraints, function(constraint, key) {
+    forEach(this.constraints, function(constraint, key) {
       if (constraint === uri[key]()) {
         return;
       }

--- a/lib/asserts/us-state-assert.js
+++ b/lib/asserts/us-state-assert.js
@@ -3,10 +3,10 @@
  * Module dependencies.
  */
 
-var _ = require('lodash');
 var Validator = require('validator.js').Validator;
 var Violation = require('validator.js').Violation;
 var provinces = require('provinces');
+var some = require('lodash/collection/some');
 
 /**
  * Export `UsStateAssert`.
@@ -31,7 +31,7 @@ module.exports = function() {
       /* jshint camelcase: true */
     }
 
-    if (true !== _.some(provinces, { short: value, country: 'US' })) {
+    if (true !== some(provinces, { short: value, country: 'US' })) {
       throw new Violation(this, value);
     }
 

--- a/package.json
+++ b/package.json
@@ -41,22 +41,24 @@
   },
   "homepage": "http://seegno.github.io/validator.js-asserts/",
   "dependencies": {
-    "URIjs": "^1.15.1",
-    "bignumber.js": "^2.0.7",
-    "creditcard": "^0.1.2",
-    "isoc": "0.0.1",
-    "lodash": "^3.9.1",
-    "moment": "^2.10.3",
-    "provinces": "^1.7.1",
-    "require-dir": "^0.3.0",
-    "validator": "^3.40.0",
-    "validator.js": "^1.1.2",
-    "world-countries": "^1.7.3"
+    "lodash": "^3.10.1",
+    "validator.js": "^1.2.2"
   },
   "devDependencies": {
     "github-changes": "^1.0.0",
     "mocha": "^2.2.5",
-    "should": "^6.0.3",
-    "sinon": "^1.14.1"
+    "should": "^7.0.3",
+    "sinon": "^1.15.4"
+  },
+  "peerDependencies": {
+    "URIjs": "^1.15.1",
+    "bignumber.js": "^2.0.7",
+    "creditcard": "^0.1.2",
+    "isoc": "0.0.1",
+    "moment": "^2.10.3",
+    "provinces": "^1.7.1",
+    "require-dir": "^0.3.0",
+    "validator": "^3.40.0",
+    "world-countries": "^1.7.3"
   }
 }


### PR DESCRIPTION
npm@3 will no longer install `peerDependencies` automatically, which puts an end to package conflicts. We can now reliably trust this mechanism to avoid bloating this package.

This is semver-major, as peer dependencies must be resolved manually by the user.