### PR TITLE
Add Bank Identifier Code assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Some asserts may require additional peer dependencies. Note that from [npm 3](ht
 
 The following set of extra asserts are provided by this package:
 
+* BankIdentifierCode (*BIC*)
 * BigNumber (requires `bignumber.js`)
 * BigNumberGreaterThan (requires `bignumber.js`)
 * BigNumberGreaterThanOrEqualTo (requires `bignumber.js`)
@@ -46,6 +47,10 @@ The following set of extra asserts are provided by this package:
 * Uri (requires `URIjs`)
 * UsState (requires `provinces`)
 * Uuid
+
+### BankIdentifierCode (*BIC*)
+
+Tests if the value is a valid Bank Identifier Code (*BIC*) as defined in the [ISO-9362](http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=60390) standard.
 
 ### BigNumber
 

--- a/src/asserts/bank-identifier-code-assert.js
+++ b/src/asserts/bank-identifier-code-assert.js
@@ -1,0 +1,43 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { Validator, Violation } from 'validator.js';
+
+/**
+ * Bic regex.
+ */
+
+const bic = /^[a-zA-Z]{6}[a-zA-Z0-9]{2}([a-zA-Z0-9]{3})?$/;
+
+/**
+ * Export `BankIdentifierCodeAssert`.
+ */
+
+export default function() {
+
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'BankIdentifierCode';
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = value => {
+    if (typeof value !== 'string') {
+      throw new Violation(this, value, { value: Validator.errorCode.must_be_a_string });
+    }
+
+    if (!bic.test(value)) {
+      throw new Violation(this, value);
+    }
+
+    return true;
+  };
+
+  return this;
+}

--- a/test/asserts/bank-identifier-code-assert_test.js
+++ b/test/asserts/bank-identifier-code-assert_test.js
@@ -1,0 +1,66 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { Assert as BaseAssert, Violation } from 'validator.js';
+import BankIdentifierCodeAssert from '../../src/asserts/bank-identifier-code-assert';
+import should from 'should';
+
+/**
+ * Extend `Assert` with `BankIdentifierCodeAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  BankIdentifierCode: BankIdentifierCodeAssert
+});
+
+/**
+ * Test `BankIdentifierCodeAssert`.
+ */
+
+describe('BankIdentifierCodeAssert', () => {
+  it('should throw an error if the input value is not a string', () => {
+    const choices = [[], {}];
+
+    choices.forEach(choice => {
+      try {
+        new Assert().BankIdentifierCode().validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        e.violation.value.should.equal('must_be_a_string');
+      }
+    });
+  });
+
+  it('should throw an error if the input value is not a valid bic', () => {
+    try {
+      new Assert().BankIdentifierCode().validate('foobar');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.value.should.equal('foobar');
+    }
+  });
+
+  it('should expose `assert` equal to `BankIdentifierCode`', () => {
+    try {
+      new Assert().BankIdentifierCode().validate(123);
+
+      should.fail();
+    } catch(e) {
+      e.show().assert.should.equal('BankIdentifierCode');
+    }
+  });
+
+  it('should accept a valid bic without branch code', () => {
+    new Assert().BankIdentifierCode().validate('FOOBARBI');
+  });
+
+  it('should accept a valid bic with branch code', () => {
+    new Assert().BankIdentifierCode().validate('FOOBARBIXXX');
+  });
+});

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -12,6 +12,7 @@ import asserts from '../src';
 describe('validator.js-asserts', () => {
   it('should export all asserts', () => {
     Object.keys(asserts).should.eql([
+      'BankIdentifierCode',
       'BigNumber',
       'BigNumberGreaterThan',
       'BigNumberGreaterThanOrEqualTo',


### PR DESCRIPTION
Adds an assert to test whether a value is a valid Bank Identifier Code (*BIC*) as defined in the [ISO-9362](http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=60390) standard.