### PR TITLE
Add empty object violation to EqualKeys assert

### DIFF
--- a/src/asserts/equal-keys-assert.js
+++ b/src/asserts/equal-keys-assert.js
@@ -4,7 +4,7 @@
  */
 
 import { Violation } from 'validator.js';
-import { difference, isPlainObject } from 'lodash';
+import { difference, isEmpty, isPlainObject } from 'lodash';
 
 /**
  * Export `EqualKeysAssert`.
@@ -31,6 +31,10 @@ export default function(keys) {
   this.validate = (value) => {
     if (!isPlainObject(value)) {
       throw new Violation(this, value, { value: 'must_be_a_plain_object' });
+    }
+
+    if (isEmpty(value)) {
+      throw new Violation(this, value, { difference: this.keys });
     }
 
     const diff = difference(Object.keys(value), this.keys);

--- a/test/asserts/equal-keys-assert_test.js
+++ b/test/asserts/equal-keys-assert_test.js
@@ -35,6 +35,16 @@ describe('EqualKeysAssert', () => {
     });
   });
 
+  it('should throw an error if the given object is empty', () => {
+    try {
+      new Assert().EqualKeys(['foo']).validate({});
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+    }
+  });
+
   it('should throw an error if an object does not have the expected keys', () => {
     try {
       new Assert().EqualKeys(['foo']).validate({ foo: 'qux', bar: 'biz' });


### PR DESCRIPTION
Since validating an empty object against the `EqualKeys` assert does not raise any error, this PR adds validation for empty input values, exposing the expected keys on the thrown violation.