### PR TITLE
Fix peer dependencies being required directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Install the package via `npm`:
 $ npm install --save validator.js-asserts
 ```
 
-Some asserts may require additional peer dependencies. Note that from [npm 3](https://github.com/npm/npm/blob/master/CHANGELOG.md#peerdependencies) forward, you must manually install them as they become necessary.
+### Peer dependencies
+
+Some asserts require manually installing some *peer dependencies*. Failing to do so will result in runtime errors, as packages are required dynamically.
+
+Peer dependencies are not listed on `package.json` because npm 2 considers them *mandatory peer dependencies* and, therefore, always installs them, while [npm 3](https://github.com/npm/npm/blob/master/CHANGELOG.md#peerdependencies) follows a more consensual approach of *optional peer dependencies*, not installing them by default but generating warning and confusing error messages instead.
+
+You should pin these package's peer dependencies to the ranges listed on the *optionalPeerDependencies* key of this package's manifest.
 
 ## Asserts
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "validator": "^4.1.0",
     "world-countries": "^1.7.3"
   },
-  "peerDependencies": {
+  "optionalPeerDependencies": {
     "urijs": ">=1 <2",
     "bignumber.js": ">=2 <3",
     "creditcard": ">=0.0.1 <1.0.0",

--- a/src/asserts/big-number-assert.js
+++ b/src/asserts/big-number-assert.js
@@ -4,13 +4,18 @@
  */
 
 import { Violation } from 'validator.js';
-import BigNumber from 'bignumber.js';
 
 /**
  * Export `BigNumberAssert`.
  */
 
 export default function() {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const BigNumber = require('bignumber.js');
 
   /**
    * Class name.

--- a/src/asserts/big-number-greater-than-assert.js
+++ b/src/asserts/big-number-greater-than-assert.js
@@ -4,13 +4,18 @@
  */
 
 import { Violation } from 'validator.js';
-import BigNumber from 'bignumber.js';
 
 /**
  * Export `BigNumberGreaterThanAssert`.
  */
 
 export default function(threshold) {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const BigNumber = require('bignumber.js');
 
   /**
    * Class name.

--- a/src/asserts/big-number-greater-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-greater-than-or-equal-to-assert.js
@@ -4,13 +4,18 @@
  */
 
 import { Violation } from 'validator.js';
-import BigNumber from 'bignumber.js';
 
 /**
  * Export `BigNumberGreaterThanOrEqualToAssert`.
  */
 
 export default function(threshold) {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const BigNumber = require('bignumber.js');
 
   /**
    * Class name.

--- a/src/asserts/big-number-less-than-assert.js
+++ b/src/asserts/big-number-less-than-assert.js
@@ -4,13 +4,18 @@
  */
 
 import { Violation } from 'validator.js';
-import BigNumber from 'bignumber.js';
 
 /**
  * Export `BigNumberLessThan`.
  */
 
 export default function(threshold) {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const BigNumber = require('bignumber.js');
 
   /**
    * Class name.

--- a/src/asserts/big-number-less-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-less-than-or-equal-to-assert.js
@@ -4,13 +4,18 @@
  */
 
 import { Violation } from 'validator.js';
-import BigNumber from 'bignumber.js';
 
 /**
  * Export `BigNumberLessThanOrEqualToAssert`.
  */
 
 export default function(threshold) {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const BigNumber = require('bignumber.js');
 
   /**
    * Class name.

--- a/src/asserts/country-assert.js
+++ b/src/asserts/country-assert.js
@@ -5,21 +5,26 @@
 
 import { Validator, Violation } from 'validator.js';
 import { find } from 'lodash';
-import besDivisions from 'world-countries/data/bes.divisions';
-import shnDivisions from 'world-countries/data/shn.divisions';
-import worldCountries from 'world-countries';
-
-/**
- * Countries data source.
- */
-
-const countries = worldCountries.concat(besDivisions, shnDivisions);
 
 /**
  * Export `CountryAssert`.
  */
 
 export default function() {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const besDivisions = require('world-countries/data/bes.divisions');
+  const shnDivisions = require('world-countries/data/shn.divisions');
+  const worldCountries = require('world-countries');
+
+  /**
+   * Countries data source.
+   */
+
+  const countries = worldCountries.concat(besDivisions, shnDivisions);
 
   /**
    * Class name.

--- a/src/asserts/credit-card-assert.js
+++ b/src/asserts/credit-card-assert.js
@@ -4,13 +4,18 @@
  */
 
 import { Violation } from 'validator.js';
-import creditcard from 'creditcard';
 
 /**
  * Export `CreditCardAssert`.
  */
 
 export default function() {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const creditcard = require('creditcard');
 
   /**
    * Class name.

--- a/src/asserts/date-diff-greater-than-assert.js
+++ b/src/asserts/date-diff-greater-than-assert.js
@@ -5,13 +5,18 @@
 
 import { Violation } from 'validator.js';
 import { assign } from 'lodash';
-import moment from 'moment';
 
 /**
  * Export `DateDiffGreaterThanAssert`.
  */
 
 export default function(threshold, options) {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const moment = require('moment');
 
   /**
    * Class name.

--- a/src/asserts/date-diff-less-than-assert.js
+++ b/src/asserts/date-diff-less-than-assert.js
@@ -5,13 +5,18 @@
 
 import { Violation } from 'validator.js';
 import { assign } from 'lodash';
-import moment from 'moment';
 
 /**
  * Export `DateDiffLessThanAssert`.
  */
 
 export default function(threshold, options) {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const moment = require('moment');
 
   /**
    * Class name.

--- a/src/asserts/email-assert.js
+++ b/src/asserts/email-assert.js
@@ -4,13 +4,18 @@
 */
 
 import { Assert, Validator, Violation } from 'validator.js';
-import Asserts from 'validator';
 
 /**
 * Export `EmailAssert`.
 */
 
 export default function() {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const validator = require('validator');
 
   /**
    * Class name.
@@ -27,7 +32,7 @@ export default function() {
       throw new Violation(this, value, { value: Validator.errorCode.must_be_a_string });
     }
 
-    if (!Asserts.isEmail(value)) {
+    if (!validator.isEmail(value)) {
       throw new Violation(this, value);
     }
 

--- a/src/asserts/international-bank-account-number-assert.js
+++ b/src/asserts/international-bank-account-number-assert.js
@@ -4,13 +4,18 @@
  */
 
 import { Validator, Violation } from 'validator.js';
-import iban from 'iban';
 
 /**
  * Export `InternationalBankAccountNumberAssert`.
  */
 
 export default function() {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const iban = require('iban');
 
   /**
    * Class name.

--- a/src/asserts/iso-3166-country-assert.js
+++ b/src/asserts/iso-3166-country-assert.js
@@ -5,13 +5,18 @@
 
 import { Validator, Violation } from 'validator.js';
 import { find } from 'lodash';
-import countries from 'isoc';
 
 /**
  * Export `Iso3166CountryAssert`.
  */
 
 export default function() {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const countries = require('isoc');
 
   /**
    * Class name.

--- a/src/asserts/uri-assert.js
+++ b/src/asserts/uri-assert.js
@@ -5,13 +5,18 @@
 
 import { Validator, Violation } from 'validator.js';
 import { forEach, has } from 'lodash';
-import URI from 'urijs';
 
 /**
 * Export `UriAssert`.
 */
 
 export default function(constraints) {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const URI = require('urijs');
 
   /**
    * Class name.

--- a/src/asserts/us-state-assert.js
+++ b/src/asserts/us-state-assert.js
@@ -5,13 +5,18 @@
 
 import { Validator, Violation } from 'validator.js';
 import { some } from 'lodash';
-import provinces from 'provinces';
 
 /**
  * Export `UsStateAssert`.
  */
 
 export default function() {
+
+  /**
+   * Optional peer dependencies.
+   */
+
+  const provinces = require('provinces');
 
   /**
    * Class name.


### PR DESCRIPTION
With _npm 3.x_ peer dependencies are no longer installed automatically. This causes warnings like the following for our users:

```js
npm WARN EPEERINVALID validator.js-asserts@1.1.0 requires a peer of urijs@>=1 <2 but none was installed.
```

_Note that this is a warning, not an error._

There is no good way around this warning and I still think that "peerDependencies" is the best way to announce to other developers that this package includes "optional peer dependencies" (for the lack of a better term).

Since this module is now being transpiled from ES6 to ES5, we cannot simply wrap the `import` statements with a _try/catch_ so this PR simply reintroduces the `require` statement inside each exported assert function (because `import` can only be used at the top of the file).

If this PR is merged users will only receive errors about missing packages at the moment when they attempt to use one of these Asserts.

Fixes #31.

R=@ruimarinho