### PR TITLE
Add support for the special `is` urijs constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Tests if the value is a plain object.
 
 Tests if the value is a valid `uri` which must contain at least a protocol and a hostname.
 
-* `constraints` (optional) - additional uri parts to test for (e.g. `{ protocol: 'https' }`).
+* `constraints` (optional) - additional uri parts to test for (e.g. `{ is: 'domain', protocol: 'https' }`).
 
 ### UsSubdivision
 

--- a/src/asserts/uri-assert.js
+++ b/src/asserts/uri-assert.js
@@ -58,7 +58,11 @@ export default function uriAssert(constraints) {
 
     // Validate that each constraint matches exactly.
     forEach(this.constraints, (constraint, key) => {
-      if (constraint === uri[key]()) {
+      if (key === 'is' && uri[key](constraint)) {
+        return;
+      }
+
+      if (key !== 'is' && constraint === uri[key]()) {
         return;
       }
 

--- a/test/asserts/uri-assert_test.js
+++ b/test/asserts/uri-assert_test.js
@@ -78,6 +78,16 @@ describe('UriAssert', () => {
     }
   });
 
+  it('should throw an error if the uri does not match the `is` constraint', () => {
+    try {
+      new Assert().Uri({ is: 'ip' }).validate('https://foobar.com');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+    }
+  });
+
   it('should expose `constraints` on the violation', () => {
     try {
       new Assert().Uri({ protocol: 'http' }).validate('https://foobar.com');
@@ -99,6 +109,7 @@ describe('UriAssert', () => {
   });
 
   it('should accept an uri that matches the constraints', () => {
+    new Assert().Uri({ is: 'domain' }).validate('https://foobar.com');
     new Assert().Uri({ protocol: 'https' }).validate('https://foobar.com');
   });
 


### PR DESCRIPTION
This allows testing for specific types of URIs, e.g., `ip`, `domain`, `relative`, `absolute`, etc.