### PR TITLE
Add format option to date assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Tests if the value is a valid credit card number using the Luhn10 algorithm.
 ### Date
 Tests if the value is a valid date.
 
+#### Arguments
+- `format` (optional) - the format in which the date must be in.
+
 ### DateDiffGreaterThan
 Tests if the difference between two dates is greater than a given threshold.
 

--- a/src/asserts/date-assert.js
+++ b/src/asserts/date-assert.js
@@ -4,17 +4,42 @@
  */
 
 import { Violation } from 'validator.js';
+import { isString } from 'lodash';
 
 /**
  * Export `DateAssert`.
  */
 
-export default function dateAssert() {
+export default function dateAssert({ format } = {}) {
   /**
    * Class name.
    */
 
   this.__class__ = 'Date';
+
+  /**
+   * Optional peer dependency.
+   */
+
+  let moment;
+
+  /**
+   * Validate format.
+   */
+
+  if (format) {
+    if (!isString(format)) {
+      throw new Error(`Unsupported format ${format} given`);
+    }
+
+    moment = require('moment');
+  }
+
+  /**
+   * Format to match the input.
+   */
+
+  this.format = format;
 
   /**
    * Validation algorithm.
@@ -26,6 +51,14 @@ export default function dateAssert() {
     }
 
     if (isNaN(Date.parse(value)) === true) {
+      throw new Violation(this, value);
+    }
+
+    if (!this.format) {
+      return true;
+    }
+
+    if (!moment(value, this.format, true).isValid()) {
       throw new Violation(this, value);
     }
 

--- a/test/asserts/date-assert_test.js
+++ b/test/asserts/date-assert_test.js
@@ -35,6 +35,43 @@ describe('DateAssert', () => {
     });
   });
 
+  it('should throw an error if an invalid format is given', () => {
+    const formats = [[], {}, 123];
+
+    formats.forEach(format => {
+      try {
+        new Assert().Date({ format }).validate();
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Error);
+        e.message.should.equal(`Unsupported format ${format} given`);
+      }
+    });
+  });
+
+  it('should throw an error if value is not correctly formatted', () => {
+    try {
+      new Assert().Date({ format: 'YYYY-MM-DD' }).validate('20003112');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().assert.should.equal('Date');
+    }
+  });
+
+  it('should throw an error if value does not pass strict validation', () => {
+    try {
+      new Assert().Date({ format: 'YYYY-MM-DD' }).validate('2000.12.30');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().assert.should.equal('Date');
+    }
+  });
+
   it('should expose `assert` equal to `Date`', () => {
     try {
       new Assert().Date().validate('foo');
@@ -47,6 +84,10 @@ describe('DateAssert', () => {
 
   it('should accept a `Date`', () => {
     new Assert().Date().validate(new Date());
+  });
+
+  it('should accept a correctly formatted date', () => {
+    new Assert().Date({ format: 'YYYY-MM-DD' }).validate('2000-12-30');
   });
 
   it('should accept a `string`', () => {


### PR DESCRIPTION
This PR adds a `format` option to the `DateAssert` that allows to check if a date is valid in a given format.