### PR TITLE
Improve date asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Tests if the value is `null` or a valid date.
 - `format` (optional) - the format in which the date must be in.
 
 ### NullOrString
-Tests if the value is a `null` or `string`, optionally within some boundaries.
+Tests if the value is `null` or a string, optionally within some boundaries.
 
 #### Arguments
 - `boundaries` (optional) - `max` and/or `min` boundaries to test the string for.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following set of extra asserts are provided by this package:
 - [Iso3166Country](#iso3166country) (requires `isoc`)
 - [Json](#json)
 - [NotEmpty](#notempty)
-- [NullOrDate](#nullordate)
+- [NullOrDate](#nullordate) (requires `moment` for format validation only)
 - [NullOrString](#nullorstring)
 - [Phone](#phone) (requires `google-libphonenumber`)
 - [PlainObject](#plainobject)
@@ -151,6 +151,12 @@ Tests if the value is valid json.
 
 ### NotEmpty
 Tests if the value is not an empty (empty object, empty array, empty string, etc).
+
+### NullOrDate
+Tests if the value is `null` or a valid date.
+
+#### Arguments
+- `format` (optional) - the format in which the date must be in.
 
 ### NullOrString
 Tests if the value is a `null` or `string`, optionally within some boundaries.

--- a/src/asserts/date-assert.js
+++ b/src/asserts/date-assert.js
@@ -50,15 +50,15 @@ export default function dateAssert({ format } = {}) {
       throw new Violation(this, value, { value: 'must_be_a_date_or_a_string' });
     }
 
-    if (isNaN(Date.parse(value)) === true) {
-      throw new Violation(this, value);
-    }
+    if (this.format) {
+      if (!moment(value, this.format, true).isValid()) {
+        throw new Violation(this, value);
+      }
 
-    if (!this.format) {
       return true;
     }
 
-    if (!moment(value, this.format, true).isValid()) {
+    if (isNaN(Date.parse(value)) === true) {
       throw new Violation(this, value);
     }
 

--- a/src/asserts/date-diff-greater-than-assert.js
+++ b/src/asserts/date-diff-greater-than-assert.js
@@ -57,7 +57,7 @@ export default function dateDiffGreaterThanAssert(threshold, options) {
       throw new Violation(this, value, { value: 'must_be_a_date_or_a_string' });
     }
 
-    if (isNaN(Date.parse(value)) === true) {
+    if (!moment(value).isValid()) {
       throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
     }
 

--- a/src/asserts/date-diff-less-than-assert.js
+++ b/src/asserts/date-diff-less-than-assert.js
@@ -57,7 +57,7 @@ export default function dateDiffLessThanAssert(threshold, options) {
       throw new Violation(this, value, { value: 'must_be_a_date_or_a_string' });
     }
 
-    if (isNaN(Date.parse(value)) === true) {
+    if (!moment(value).isValid()) {
       throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
     }
 

--- a/src/asserts/null-or-date-assert.js
+++ b/src/asserts/null-or-date-assert.js
@@ -4,17 +4,42 @@
  */
 
 import { Violation } from 'validator.js';
+import { isString } from 'lodash';
 
 /**
  * Export `NullOrDateAssert`.
  */
 
-export default function nullOrDateAssert() {
+export default function nullOrDateAssert({ format } = {}) {
   /**
    * Class name.
    */
 
   this.__class__ = 'NullOrDate';
+
+  /**
+   * Optional peer dependency.
+   */
+
+  let moment;
+
+  /**
+   * Validate format.
+   */
+
+  if (format) {
+    if (!isString(format)) {
+      throw new Error(`Unsupported format ${format} given`);
+    }
+
+    moment = require('moment');
+  }
+
+  /**
+   * Format to match the input.
+   */
+
+  this.format = format;
 
   /**
    * Validation algorithm.
@@ -26,6 +51,14 @@ export default function nullOrDateAssert() {
     }
 
     if (value === null) {
+      return true;
+    }
+
+    if (this.format) {
+      if (!moment(value, this.format, true).isValid()) {
+        throw new Violation(this, value);
+      }
+
       return true;
     }
 

--- a/test/asserts/date-assert_test.js
+++ b/test/asserts/date-assert_test.js
@@ -82,15 +82,15 @@ describe('DateAssert', () => {
     }
   });
 
-  it('should accept a `Date`', () => {
+  it('should accept a date', () => {
     new Assert().Date().validate(new Date());
   });
 
   it('should accept a correctly formatted date', () => {
-    new Assert().Date({ format: 'YYYY-MM-DD' }).validate('2000-12-30');
+    new Assert().Date({ format: 'MM/YYYY' }).validate('12/2000');
   });
 
-  it('should accept a `string`', () => {
+  it('should accept a string', () => {
     new Assert().Date().validate('2014-10-16');
   });
 });

--- a/test/asserts/null-or-date-assert_test.js
+++ b/test/asserts/null-or-date-assert_test.js
@@ -35,14 +35,40 @@ describe('NullOrDateAssert', () => {
     });
   });
 
-  it('should throw an error if the input value is not a valid date', () => {
+  it('should throw an error if an invalid format is given', () => {
+    const formats = [[], {}, 123];
+
+    formats.forEach(format => {
+      try {
+        new Assert().NullOrDate({ format }).validate();
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Error);
+        e.message.should.equal(`Unsupported format ${format} given`);
+      }
+    });
+  });
+
+  it('should throw an error if value is not correctly formatted', () => {
     try {
-      new Assert().NullOrDate().validate('2015-99-01');
+      new Assert().NullOrDate({ format: 'YYYY-MM-DD' }).validate('20003112');
 
       should.fail();
     } catch (e) {
       e.should.be.instanceOf(Violation);
-      e.show().value.should.equal('2015-99-01');
+      e.show().assert.should.equal('NullOrDate');
+    }
+  });
+
+  it('should throw an error if value does not pass strict validation', () => {
+    try {
+      new Assert().NullOrDate({ format: 'YYYY-MM-DD' }).validate('2000.12.30');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().assert.should.equal('NullOrDate');
     }
   });
 
@@ -62,6 +88,10 @@ describe('NullOrDateAssert', () => {
 
   it('should accept a date', () => {
     new Assert().NullOrDate().validate(new Date());
+  });
+
+  it('should accept a correctly formatted date', () => {
+    new Assert().NullOrDate({ format: 'MM/YYYY' }).validate('12/2000');
   });
 
   it('should accept a string', () => {


### PR DESCRIPTION
This PR:

* Improves the date assert by validating using the moment API. This now allows the following assert to work:

```js
new Assert().Date({ format: 'MM/YYYY' }).validate('11/2016');
```

* Adds optional format to `NullOrDate` assert.
* Improves date validation in the date diff asserts by using _moment's_ parsing.
* Fixes a typo in the README.

_Note_: due to the changes in the way dates are handled, this PR could constitute a BC and releasing a major bump is recommended.