### PR TITLE
Add `BigNumberEqualTo` assert to `dist`

### DIFF
--- a/dist/asserts/big-number-equal-to-assert.js
+++ b/dist/asserts/big-number-equal-to-assert.js
@@ -1,0 +1,63 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = bigNumberEqualToAssert;
+
+var _validator = require('validator.js');
+
+/**
+ * Export `BigNumberEqualToAssert`.
+ */
+
+function bigNumberEqualToAssert(value) {
+  /**
+   * Optional peer dependencies.
+   */
+
+  const BigNumber = require('bignumber.js');
+
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'BigNumberEqualTo';
+
+  if (typeof value === 'undefined') {
+    throw new Error('A value is required.');
+  }
+
+  this.value = new BigNumber(value);
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = value => {
+    try {
+      const number = new BigNumber(value);
+
+      if (!number.equals(this.value)) {
+        throw new Error();
+      }
+    } catch (e) {
+      const context = { value: this.value.toString() };
+
+      if (e.name === 'BigNumber Error') {
+        context.message = e.message;
+      }
+
+      throw new _validator.Violation(this, value, context);
+    }
+
+    return true;
+  };
+
+  return this;
+}
+/**
+ * Module dependencies.
+ */
+
+module.exports = exports['default'];

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,6 +16,10 @@ var _bigNumberAssert = require('./asserts/big-number-assert.js');
 
 var _bigNumberAssert2 = _interopRequireDefault(_bigNumberAssert);
 
+var _bigNumberEqualToAssert = require('./asserts/big-number-equal-to-assert.js');
+
+var _bigNumberEqualToAssert2 = _interopRequireDefault(_bigNumberEqualToAssert);
+
 var _bigNumberGreaterThanAssert = require('./asserts/big-number-greater-than-assert.js');
 
 var _bigNumberGreaterThanAssert2 = _interopRequireDefault(_bigNumberGreaterThanAssert);
@@ -134,10 +138,15 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * Module dependencies.
  */
 
+/**
+ * Module dependencies.
+ */
+
 exports.default = {
   AbaRoutingNumber: _abaRoutingNumberAssert2.default,
   BankIdentifierCode: _bankIdentifierCodeAssert2.default,
   BigNumber: _bigNumberAssert2.default,
+  BigNumberEqualTo: _bigNumberEqualToAssert2.default,
   BigNumberGreaterThan: _bigNumberGreaterThanAssert2.default,
   BigNumberGreaterThanOrEqualTo: _bigNumberGreaterThanOrEqualToAssert2.default,
   BigNumberLessThan: _bigNumberLessThanAssert2.default,
@@ -167,8 +176,4 @@ exports.default = {
   UsZipCode: _usZipCodeAssert2.default,
   Uuid: _uuidAssert2.default
 };
-/**
- * Module dependencies.
- */
-
 module.exports = exports['default'];


### PR DESCRIPTION
This assert was recently added to the project. However, it mustn't have been transpiled, because it wasn't available in `dist` yet. This means projects depending on this still don't have access to this new assert.

This PR runs the transpile command to add `BigNumberEqualTo` to `dist` and this make it available to other projects.