### PR TITLE
Allow custom date formats

### DIFF
--- a/src/asserts/date-assert.js
+++ b/src/asserts/date-assert.js
@@ -28,10 +28,6 @@ export default function dateAssert({ format } = {}) {
    */
 
   if (format) {
-    if (!isString(format)) {
-      throw new Error(`Unsupported format ${format} given`);
-    }
-
     moment = require('moment');
   }
 

--- a/test/asserts/date-assert_test.js
+++ b/test/asserts/date-assert_test.js
@@ -35,21 +35,6 @@ describe('DateAssert', () => {
     });
   });
 
-  it('should throw an error if an invalid format is given', () => {
-    const formats = [[], {}, 123];
-
-    formats.forEach(format => {
-      try {
-        new Assert().Date({ format }).validate();
-
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.equal(`Unsupported format ${format} given`);
-      }
-    });
-  });
-
   it('should throw an error if value is not correctly formatted', () => {
     try {
       new Assert().Date({ format: 'YYYY-MM-DD' }).validate('20003112');


### PR DESCRIPTION
This PR removes the need for `format` to be a string in `DateAssert`.
As documented in [moment](http://momentjs.com/docs/#/parsing/special-formats/), the format can be a string, a array or a function. 
By having this limitation we can't support parsing a date with multiple formats such as ISO8601 or custom ones.