### PR TITLE
Support allowing specific phone types

### DIFF
--- a/test/asserts/phone-assert_test.js
+++ b/test/asserts/phone-assert_test.js
@@ -20,6 +20,19 @@ const Assert = BaseAssert.extend({
  */
 
 describe('Phone', () => {
+  it('should throw an error if the allowed types are invalid', () => {
+    ['foobar', ['foobar']].forEach(types => {
+      try {
+        new Assert().Phone({ allowedTypes: types }).validate('+1 415 555 2671');
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Error);
+        e.message.should.equal('Phone types specified are not valid.');
+      }
+    });
+  });
+
   it('should throw an error if the input value is not a string', () => {
     [{}, [], 123].forEach(choice => {
       try {
@@ -47,6 +60,17 @@ describe('Phone', () => {
   it('should throw an error if the phone does not belong to the given country', () => {
     try {
       new Assert().Phone({ countryCode: 'US' }).validate('912345578');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().assert.should.equal('Phone');
+    }
+  });
+
+  it('should throw an error if the phone does not have one of the given allowed types', () => {
+    try {
+      new Assert().Phone({ allowedTypes: ['FIXED_LINE', 'MOBILE'] }).validate('+1 415 555 2671');
 
       should.fail();
     } catch (e) {


### PR DESCRIPTION
This PR adds the ability to specify the phones types allowed in the `Phone` assert.
With this we can, for example, only allow land line and mobile phones (avoid premium numbers).