### PR TITLE
New date asserts

### DIFF
--- a/src/asserts/date-diff-greater-than-or-equal-to-assert.js
+++ b/src/asserts/date-diff-greater-than-or-equal-to-assert.js
@@ -1,0 +1,78 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { Violation } from 'validator.js';
+import { assign } from 'lodash';
+
+/**
+ * Export `DateDiffGreaterThanOrEqualToAssert`.
+ */
+
+export default function dateDiffGreaterThanOrEqualToAssert(threshold, options) {
+  /**
+   * Optional peer dependencies.
+   */
+
+  const moment = require('moment');
+
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'DateDiffGreaterThanOrEqualTo';
+
+  /**
+   * Check if `threshold` is defined.
+   */
+
+  if (typeof threshold === 'undefined') {
+    throw new Error('A threshold value is required.');
+  }
+
+  /**
+   * Threshold.
+   */
+
+  this.threshold = threshold;
+
+  /**
+   * Options.
+   */
+
+  this.options = assign(this, {
+    absolute: false,
+    asFloat: false,
+    fromDate: null,
+    unit: 'milliseconds'
+  }, options);
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = value => {
+    if (typeof value !== 'string' && Object.prototype.toString.call(value) !== '[object Date]') {
+      throw new Violation(this, value, { value: 'must_be_a_date_or_a_string' });
+    }
+
+    if (isNaN(Date.parse(value)) === true) {
+      throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
+    }
+
+    let diff = moment(this.fromDate || Date.now()).diff(value, this.unit, this.asFloat);
+
+    if (this.absolute) {
+      diff = Math.abs(diff);
+    }
+
+    if (diff < this.threshold) {
+      throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, diff, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
+    }
+
+    return true;
+  };
+
+  return this;
+}

--- a/src/asserts/date-diff-less-than-or-equal-to-assert.js
+++ b/src/asserts/date-diff-less-than-or-equal-to-assert.js
@@ -1,0 +1,78 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { Violation } from 'validator.js';
+import { assign } from 'lodash';
+
+/**
+ * Export `DateDiffLessThanOrEqualToAssert`.
+ */
+
+export default function dateDiffLessThanOrEqualToAssert(threshold, options) {
+  /**
+   * Optional peer dependencies.
+   */
+
+  const moment = require('moment');
+
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'DateDiffLessThanOrEqualTo';
+
+  /**
+   * Check if `threshold` is defined.
+   */
+
+  if (typeof threshold === 'undefined') {
+    throw new Error('A threshold value is required.');
+  }
+
+  /**
+   * Threshold.
+   */
+
+  this.threshold = threshold;
+
+  /**
+   * Options.
+   */
+
+  this.options = assign(this, {
+    absolute: false,
+    asFloat: false,
+    fromDate: null,
+    unit: 'milliseconds'
+  }, options);
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = value => {
+    if (typeof value !== 'string' && Object.prototype.toString.call(value) !== '[object Date]') {
+      throw new Violation(this, value, { value: 'must_be_a_date_or_a_string' });
+    }
+
+    if (isNaN(Date.parse(value)) === true) {
+      throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
+    }
+
+    let diff = moment(this.fromDate || Date.now()).diff(value, this.unit, this.asFloat);
+
+    if (this.absolute) {
+      diff = Math.abs(diff);
+    }
+
+    if (diff > this.threshold) {
+      throw new Violation(this, value, { absolute: this.absolute, asFloat: this.asFloat, diff, fromDate: this.fromDate, threshold: this.threshold, unit: this.unit });
+    }
+
+    return true;
+  };
+
+  return this;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import Date from './asserts/date-assert.js';
 import DateDiffGreaterThan from './asserts/date-diff-greater-than-assert.js';
 import DateDiffGreaterThanOrEqualTo from './asserts/date-diff-greater-than-or-equal-to-assert.js';
 import DateDiffLessThan from './asserts/date-diff-less-than-assert.js';
+import DateDiffLessThanOrEqualTo from './asserts/date-diff-less-than-or-equal-to-assert.js';
 import Email from './asserts/email-assert.js';
 import EqualKeys from './asserts/equal-keys-assert.js';
 import Hash from './asserts/hash-assert.js';
@@ -56,6 +57,7 @@ export default {
   DateDiffGreaterThan,
   DateDiffGreaterThanOrEqualTo,
   DateDiffLessThan,
+  DateDiffLessThanOrEqualTo,
   Email,
   EqualKeys,
   Hash,

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import Boolean from './asserts/boolean-assert.js';
 import CreditCard from './asserts/credit-card-assert.js';
 import Date from './asserts/date-assert.js';
 import DateDiffGreaterThan from './asserts/date-diff-greater-than-assert.js';
+import DateDiffGreaterThanOrEqualTo from './asserts/date-diff-greater-than-or-equal-to-assert.js';
 import DateDiffLessThan from './asserts/date-diff-less-than-assert.js';
 import Email from './asserts/email-assert.js';
 import EqualKeys from './asserts/equal-keys-assert.js';
@@ -53,6 +54,7 @@ export default {
   CreditCard,
   Date,
   DateDiffGreaterThan,
+  DateDiffGreaterThanOrEqualTo,
   DateDiffLessThan,
   Email,
   EqualKeys,

--- a/test/asserts/date-diff-greater-than-or-equal-to-assert_test.js
+++ b/test/asserts/date-diff-greater-than-or-equal-to-assert_test.js
@@ -1,0 +1,225 @@
+
+/**
+ * Module dependencies.
+ */
+
+import DateDiffGreaterThanOrEqualToAssert from '../../src/asserts/date-diff-greater-than-or-equal-to-assert';
+import should from 'should';
+import sinon from 'sinon';
+import { Assert as BaseAssert, Violation } from 'validator.js';
+
+/**
+ * Extend `Assert` with `DateDiffGreaterThanOrEqualToAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  DateDiffGreaterThanOrEqualTo: DateDiffGreaterThanOrEqualToAssert
+});
+
+/**
+ * Test `DateDiffGreaterThanOrEqualToAssert`.
+ */
+
+describe('DateDiffGreaterThanOrEqualToAssert', () => {
+  it('should throw an error if `threshold` is missing', () => {
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo();
+
+      should.fail();
+    } catch (e) {
+      e.message.should.equal('A threshold value is required.');
+    }
+  });
+
+  it('should have a default option `absolute` of `false`', () => {
+    const assert = new Assert().DateDiffGreaterThanOrEqualTo(1);
+
+    assert.options.absolute.should.be.false();
+  });
+
+  it('should have a default option `asFloat` of `false`', () => {
+    const assert = new Assert().DateDiffGreaterThanOrEqualTo(1);
+
+    assert.options.asFloat.should.be.false();
+  });
+
+  it('should have a default option `fromDate` of `null`', () => {
+    const assert = new Assert().DateDiffGreaterThanOrEqualTo(1);
+
+    (assert.options.fromDate === null).should.be.true();
+  });
+
+  it('should have a default option `unit` of `milliseconds`', () => {
+    const assert = new Assert().DateDiffGreaterThanOrEqualTo(1);
+
+    assert.options.unit.should.equal('milliseconds');
+  });
+
+  it('should throw an error if the input value is not a date', () => {
+    const choices = [[], {}];
+
+    choices.forEach(choice => {
+      try {
+        new Assert().DateDiffGreaterThanOrEqualTo(10).validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        e.violation.value.should.equal('must_be_a_date_or_a_string');
+      }
+    });
+  });
+
+  it('should throw an error if the input value is not a valid date', () => {
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo(10).validate('2015-99-01');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().value.should.equal('2015-99-01');
+    }
+  });
+
+  it('should throw an error if the diff between `now` and input date is less than the `threshold`', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1970-01-01'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.threshold.should.not.equal(e.show().violation.diff);
+    }
+
+    clock.restore();
+  });
+
+  it('should throw an error if the diff between `fromDate` and input date is less than the `threshold`', () => {
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { fromDate: new Date('1970-01-01 00:00:00') }).validate(new Date('1970-01-01 10:00:00'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.threshold.should.not.equal(e.show().violation.diff);
+    }
+  });
+
+  it('should expose `assert` equal to `DateDiffGreaterThanOrEqualToAssert`', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1970-01-01'));
+
+      should.fail();
+    } catch (e) {
+      e.show().assert.should.equal('DateDiffGreaterThanOrEqualTo');
+    }
+
+    clock.restore();
+  });
+
+  it('should expose `absolute`, `asFloat`, `diff`, `fromDate`, `threshold` and `unit` on the violation', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1970-01-01'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.should.have.keys('absolute', 'asFloat', 'diff', 'fromDate', 'threshold', 'unit');
+    }
+
+    clock.restore();
+  });
+
+  it('should accept option `asFloat`', () => {
+    const assert = new Assert().DateDiffGreaterThanOrEqualTo(0, { asFloat: true });
+
+    assert.options.asFloat.should.be.true();
+  });
+
+  it('should accept option `fromDate`', () => {
+    const assert = new Assert().DateDiffGreaterThanOrEqualTo(0, { fromDate: new Date('1970-01-01') });
+
+    assert.options.fromDate.should.eql(new Date('1970-01-01'));
+  });
+
+  it('should accept option `unit`', () => {
+    const assert = new Assert().DateDiffGreaterThanOrEqualTo(24, { unit: 'hours' });
+
+    assert.options.unit.should.equal('hours');
+  });
+
+  it('should use the `asFloat` option supplied', () => {
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00'), unit: 'minutes' }).validate(new Date('1970-01-01 10:04:51'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.diff.should.equal(-4.85);
+    }
+  });
+
+  it('should use the `unit` option supplied', () => {
+    try {
+      new Assert().DateDiffGreaterThanOrEqualTo(2000, { fromDate: new Date('1970-01-01 10:00:00'), unit: 'seconds' }).validate(new Date('1970-01-01 10:00:05'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+    }
+  });
+
+  it('should accept a date whose diff from `now` is equal to the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 00:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose diff from `now` is greater than the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-30 00:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose `absolute` diff from `now` is equal to the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-02 00:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose `absolute` diff from `now` is greater than the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-03 00:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose diff from `fromDate` is equal to the threshold', () => {
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-31 00:00:00'));
+  });
+
+  it('should accept a date whose diff from `fromDate` is greater than the threshold', () => {
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-30 00:00:00'));
+  });
+
+  it('should accept a date whose `absolute` diff from `fromDate` is equal to the threshold', () => {
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-02 00:00:00'));
+  });
+
+  it('should accept a date whose `absolute` diff from `fromDate` is greater than the threshold', () => {
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-03 00:00:00'));
+  });
+});

--- a/test/asserts/date-diff-less-than-or-equal-to-assert_test.js
+++ b/test/asserts/date-diff-less-than-or-equal-to-assert_test.js
@@ -1,0 +1,245 @@
+
+/**
+ * Module dependencies.
+ */
+
+import DateDiffLessThanOrEqualToAssert from '../../src/asserts/date-diff-less-than-or-equal-to-assert';
+import should from 'should';
+import sinon from 'sinon';
+import { Assert as BaseAssert, Violation } from 'validator.js';
+
+/**
+ * Extend `Assert` with `DateDiffLessThanOrEqualToAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  DateDiffLessThanOrEqualTo: DateDiffLessThanOrEqualToAssert
+});
+
+/**
+ * Test `DateDiffLessThanOrEqualToAssert`.
+ */
+
+describe('DateDiffLessThanOrEqualToAssert', () => {
+  it('should throw an error if `threshold` is missing', () => {
+    try {
+      new Assert().DateDiffLessThanOrEqualTo();
+
+      should.fail();
+    } catch (e) {
+      e.message.should.equal('A threshold value is required.');
+    }
+  });
+
+  it('should have a default option `absolute` of `false`', () => {
+    const assert = new Assert().DateDiffLessThanOrEqualTo(1);
+
+    assert.options.absolute.should.be.false();
+  });
+
+  it('should have a default option `asFloat` of `false`', () => {
+    const assert = new Assert().DateDiffLessThanOrEqualTo(1);
+
+    assert.options.asFloat.should.be.false();
+  });
+
+  it('should have a default option `fromDate` of `null`', () => {
+    const assert = new Assert().DateDiffLessThanOrEqualTo(1);
+
+    (assert.options.fromDate === null).should.be.true();
+  });
+
+  it('should have a default option `unit` of `milliseconds`', () => {
+    const assert = new Assert().DateDiffLessThanOrEqualTo(1);
+
+    assert.options.unit.should.equal('milliseconds');
+  });
+
+  it('should throw an error if the input value is not a date', () => {
+    const choices = [[], {}];
+
+    choices.forEach(choice => {
+      try {
+        new Assert().DateDiffLessThanOrEqualTo(10).validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        e.violation.value.should.equal('must_be_a_date_or_a_string');
+      }
+    });
+  });
+
+  it('should throw an error if the input value is not a valid date', () => {
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(10).validate('2015-99-01');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().value.should.equal('2015-99-01');
+    }
+  });
+
+  it('should throw an error if the diff between `now` and input date is greater than the `threshold`', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-30'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.threshold.should.not.equal(e.show().violation.diff);
+    }
+
+    clock.restore();
+  });
+
+  it('should throw an error if the `absolute` diff between `now` and input date is greater than the `threshold`', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-03'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.threshold.should.not.equal(e.show().violation.diff);
+    }
+
+    clock.restore();
+  });
+
+  it('should throw an error if the diff between `fromDate` and input date is greater than the `threshold`', () => {
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { fromDate: new Date('1970-01-01') }).validate(new Date('1969-12-30'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.threshold.should.not.equal(e.show().violation.diff);
+    }
+  });
+
+  it('should throw an error if the `absolute` diff between `fromDate` and input date is greater than the `threshold`', () => {
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true, fromDate: new Date('1970-01-01') }).validate(new Date('1970-01-03'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.threshold.should.not.equal(e.show().violation.diff);
+    }
+  });
+
+  it('should expose `assert` equal to `DateDiffLessThanOrEqualToAssert`', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-30'));
+
+      should.fail();
+    } catch (e) {
+      e.show().assert.should.equal('DateDiffLessThanOrEqualTo');
+    }
+
+    clock.restore();
+  });
+
+  it('should expose `absolute`, `asFloat`, `diff`, `fromDate`, `threshold` and `unit` on the violation', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-30'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.should.have.keys('absolute', 'asFloat', 'diff', 'fromDate', 'threshold', 'unit');
+    }
+
+    clock.restore();
+  });
+
+  it('should accept option `asFloat`', () => {
+    const assert = new Assert().DateDiffLessThanOrEqualTo(0, { asFloat: true });
+
+    assert.options.asFloat.should.be.true();
+  });
+
+  it('should accept option `fromDate`', () => {
+    const assert = new Assert().DateDiffLessThanOrEqualTo(0, { fromDate: new Date('1970-01-01') });
+
+    assert.options.fromDate.should.eql(new Date('1970-01-01'));
+  });
+
+  it('should accept option `unit`', () => {
+    const assert = new Assert().DateDiffLessThanOrEqualTo(24, { unit: 'hours' });
+
+    assert.options.unit.should.equal('hours');
+  });
+
+  it('should use the `asFloat` option supplied', () => {
+    try {
+      new Assert().DateDiffLessThanOrEqualTo(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00'), unit: 'minutes' }).validate(new Date('1970-01-01 09:54:57'));
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().violation.diff.should.equal(5.05);
+    }
+  });
+
+  it('should use the `unit` option supplied', () => {
+    new Assert().DateDiffLessThanOrEqualTo(2000, { fromDate: new Date('1970-01-01 10:00:00'), unit: 'seconds' }).validate(new Date('1970-01-01 09:55:55'));
+  });
+
+  it('should accept a date whose diff from `now` is equal to the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 00:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose diff from `now` is less than the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 11:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose `absolute` diff from `now` is equal to the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-02 00:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose `absolute` diff from `now` is less than the threshold', () => {
+    const clock = sinon.useFakeTimers(0, 'Date');
+
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-01 11:00:00'));
+
+    clock.restore();
+  });
+
+  it('should accept a date whose diff from `fromDate` is equal to the threshold', () => {
+    new Assert().DateDiffLessThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-31 00:00:00'));
+  });
+
+  it('should accept a date whose diff from `fromDate` is less than the threshold', () => {
+    new Assert().DateDiffLessThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-31 11:00:00'));
+  });
+
+  it('should accept a date whose `absolute` diff from `fromDate` is equal to the threshold', () => {
+    new Assert().DateDiffLessThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-02 00:00:00'));
+  });
+
+  it('should accept a date whose `absolute` diff from `fromDate` is less than the threshold', () => {
+    new Assert().DateDiffLessThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-01 11:00:00'));
+  });
+});

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -24,6 +24,7 @@ describe('validator.js-asserts', () => {
       'CreditCard',
       'Date',
       'DateDiffGreaterThan',
+      'DateDiffGreaterThanOrEqualTo',
       'DateDiffLessThan',
       'Email',
       'EqualKeys',

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -26,6 +26,7 @@ describe('validator.js-asserts', () => {
       'DateDiffGreaterThan',
       'DateDiffGreaterThanOrEqualTo',
       'DateDiffLessThan',
+      'DateDiffLessThanOrEqualTo',
       'Email',
       'EqualKeys',
       'Hash',


### PR DESCRIPTION
This PR adds two new date asserts for `less/greater than or equal to` that were missing.