### PR TITLE
Add support for underscores to be in callback assert custom class

### DIFF
--- a/src/asserts/callback-assert.js
+++ b/src/asserts/callback-assert.js
@@ -11,7 +11,7 @@ const _ = require('lodash');
  * Constants.
  */
 
-const expression = /^[a-zA-Z\d]+$/;
+const expression = /^[a-zA-Z\d_]+$/;
 
 /**
  * Export `CallbackAssert`.

--- a/test/asserts/callback-assert.test.js
+++ b/test/asserts/callback-assert.test.js
@@ -97,4 +97,12 @@ describe('CallbackAssert', () => {
       Assert.callback(value => value === 'foobar', 'CustomClass').validate('foobar');
     });
   });
+
+  it('should expose `assert` equal to `Custom_Class1`', ({ assert }) => {
+    try {
+      Assert.callback(value => value === 'foobiz', 'Custom_Class1').validate('foobar');
+    } catch (e) {
+      assert.equal(e.show().assert, 'Custom_Class1');
+    }
+  });
 });


### PR DESCRIPTION
This PR adds support for underscores to be considered valid in the callback assert custom class name.