### PR TITLE
Update UUID assert to include `v7`, `max`, and `nil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,13 +317,13 @@ Tests if the value is a valid US subdivision or not. By default, codes in the sh
 
 Tests if the value is a valid US zip code.
 
-### Uuid
+### UUID
 
 Tests if the value is a valid `UUID`.
 
 #### Arguments
 
-- `version` (optional) - the version to test the `UUID` for. Supported versions are `3`, `4` and `5`. Defaults to test for `all` three if omitted.
+- `version` (optional) - the version to test the `UUID` for. Supported versions are `3`, `4`, `5`, `7`, `max`, and `nil`. Defaults to test for `all` if omitted.
 
 ## Usage
 

--- a/src/asserts/uuid-assert.js
+++ b/src/asserts/uuid-assert.js
@@ -14,7 +14,10 @@ const uuid = {
   3: /^[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i,
   4: /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
   5: /^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
-  all: /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i
+  7: /^[0-9A-F]{8}-[0-9A-F]{4}-7[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+  all: /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i,
+  max: /^FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF$/i,
+  nil: /^00000000-0000-0000-0000-000000000000$/i
 };
 
 /**
@@ -28,7 +31,7 @@ module.exports = function uuidAssert(version) {
 
   this.__class__ = 'Uuid';
 
-  if (version && [3, 4, 5].indexOf(version) === -1) {
+  if (version && !uuid[version]) {
     throw new Error('UUID version specified is not supported.');
   }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -194,6 +194,9 @@ export interface ValidatorJSAsserts {
   /** Valid US ZIP code. */
   usZipCode(): AssertInstance;
 
-  /** Valid `UUID` (version 3, 4, or 5). */
-  uuid(version?: 3 | 4 | 5): AssertInstance;
+  /**
+   * Valid `UUID`.
+   * @param [version] - UUID version `3`, `4`, `5`, `7`, `max` or `nil`. Defaults to `all` if omitted.
+   */
+  uuid(version?: '3' | '4' | '5' | '7' | 'max' | 'nil'): AssertInstance;
 }

--- a/test/asserts/uuid-assert.test.js
+++ b/test/asserts/uuid-assert.test.js
@@ -70,21 +70,18 @@ describe('UuidAssert', () => {
     }
   });
 
-  it('should accept a v3 uuid', ({ assert }) => {
-    assert.doesNotThrow(() => {
-      Assert.uuid(3).validate('6fa459ea-ee8a-3ca4-894e-db77e160355e');
-    });
-  });
-
-  it('should accept a v4 uuid', ({ assert }) => {
-    assert.doesNotThrow(() => {
-      Assert.uuid(4).validate('17dd5a7a-637c-436e-bb8a-5398f7ac0a76');
-    });
-  });
-
-  it('should accept a v5 uuid', ({ assert }) => {
-    assert.doesNotThrow(() => {
-      Assert.uuid(5).validate('74738ff5-5367-5958-9aee-98fffdcd1876');
+  [
+    { name: 'v3', uuid: '6fa459ea-ee8a-3ca4-894e-db77e160355e', version: 3 },
+    { name: 'v4', uuid: '17dd5a7a-637c-436e-bb8a-5398f7ac0a76', version: 4 },
+    { name: 'v5', uuid: '74738ff5-5367-5958-9aee-98fffdcd1876', version: 5 },
+    { name: 'v7', uuid: '01973bbd-2012-7c70-bc1a-59c06fe30326', version: 7 },
+    { name: 'nil', uuid: '00000000-0000-0000-0000-000000000000', version: 'nil' },
+    { name: 'max', uuid: 'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF', version: 'max' }
+  ].forEach(({ name, uuid, version }) => {
+    it(`should accept a ${name} uuid`, ({ assert }) => {
+      assert.doesNotThrow(() => {
+        Assert.uuid(version).validate(uuid);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

- Enhance the `UUID` assertion to support additional versions: `v7`, `max`, and `nil`.
  See [RFC9562 for additional information](https://www.rfc-editor.org/rfc/rfc9562.html).
  - [UUIDv7](https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-7)
  - [Max UUID](https://www.rfc-editor.org/rfc/rfc9562.html#name-max-uuid)
  - [Nil UUID](https://www.rfc-editor.org/rfc/rfc9562.html#name-nil-uuid)

- Update `README` to reflect these changes and modify tests to validate the new UUID formats.
- Update its type signature to include new `UUID` versions, replacing the previous versions' integers with strings, for accuracy.

**Updated type signature**

<img width="604" height="114" alt="image" src="https://github.com/user-attachments/assets/4cb7a245-cdc1-40ee-855a-0d254fe96cbe" />

