### PR TITLE
Update `Callback` type hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Allows you to add custom rules by giving a callback function and a custom class.
 
 #### Arguments
 
-- `callback` (required) - the callback function.
-- `customClass` (required) - the name of the class.
+- `callback` (required) - the callback function, that must return `true` if the value is valid.
+- `customClass` (required) - the name of the class, which must match the pattern `/^[a-zA-Z\d]+$/`.
 
 ### CaZipCode
 
@@ -331,7 +331,9 @@ The following is an example for the extra IP assert:
 
 ```js
 const Validator = require('validator.js').Validator;
-const is = require('validator.js').Assert.extend(require('validator.js-asserts'));
+const is = require('validator.js').Assert.extend(
+  require('validator.js-asserts')
+);
 const validator = new Validator();
 
 // Validate IP `1.3.3.7`.

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -60,7 +60,18 @@ export interface ValidatorJSAsserts {
   /** Valid Canadian ZIP code (postal code). */
   caZipCode(): AssertInstance;
 
-  /** Run a custom callback function, passing a custom class name. */
+  /**
+   * Run a custom callback function, passing a custom class name.
+   * @param fn - Callback function that receives the value to validate, which should return `true` if valid.
+   * @param customClass - Custom class name to use for the assert. Must match the pattern `/^[a-zA-Z\d]+$/`.
+   * @example
+   * ```js
+   * is.callback(
+   *   (value) => typeof value === 'string' && value.length > 0,
+   *   'NonEmptyString'
+   * );
+   * ```
+   */
   callback(fn: (value: unknown) => boolean, customClass: string): AssertInstance;
 
   /** Valid Brazilian CPF number. @requires cpf */


### PR DESCRIPTION
## Description

- Clarify the `callback` method's requirements by specifying that class names on `customClass` must match the pattern `/^[a-zA-Z\d]+$/`. This enhances type safety and documentation for users of the interface.

**New type signature**

<img width="574" height="209" alt="image" src="https://github.com/user-attachments/assets/2c2af684-037e-4d7f-8432-dde12cc02d50" />
